### PR TITLE
Fix tuples

### DIFF
--- a/scylla/src/frame/cql_collections_test.rs
+++ b/scylla/src/frame/cql_collections_test.rs
@@ -162,7 +162,7 @@ async fn test_cql_collections() {
         .await.unwrap();
 
     let duration1 = (3, "hours");
-    let duration2 = CqlValue::Tuple(vec![CqlValue::Int(2), CqlValue::Text("minutes".into())]);
+    let duration2 = CqlValue::Tuple(vec![Some(CqlValue::Int(2)), Some(CqlValue::Text("minutes".into()))]);
     session
         .query(
             "INSERT INTO ks.durations (event, duration) VALUES ('ev1', ?)",

--- a/scylla/src/frame/cql_collections_test.rs
+++ b/scylla/src/frame/cql_collections_test.rs
@@ -162,7 +162,10 @@ async fn test_cql_collections() {
         .await.unwrap();
 
     let duration1 = (3, "hours");
-    let duration2 = CqlValue::Tuple(vec![Some(CqlValue::Int(2)), Some(CqlValue::Text("minutes".into()))]);
+    let duration2 = CqlValue::Tuple(vec![
+        Some(CqlValue::Int(2)),
+        Some(CqlValue::Text("minutes".into())),
+    ]);
     session
         .query(
             "INSERT INTO ks.durations (event, duration) VALUES ('ev1', ?)",
@@ -177,14 +180,21 @@ async fn test_cql_collections() {
         )
         .await
         .unwrap();
+    session
+        .query(
+            "INSERT INTO ks.durations (event, duration) VALUES ('ev3', (4, null))",
+            &[],
+        )
+        .await
+        .unwrap();
 
-    let mut received_elements: Vec<(i32, String)> = session
+    let mut received_elements: Vec<(i32, Option<String>)> = session
         .query("SELECT duration FROM ks.durations", &[])
         .await
         .unwrap()
         .rows
         .unwrap()
-        .into_typed::<((i32, String),)>()
+        .into_typed::<((i32, Option<String>),)>()
         .map(Result::unwrap)
         .map(|(x,)| x)
         .collect();
@@ -192,6 +202,10 @@ async fn test_cql_collections() {
 
     assert_eq!(
         received_elements,
-        vec![(2, "minutes".into()), (3, "hours".into())]
+        vec![
+            (2, Some("minutes".into())),
+            (3, Some("hours".into())),
+            (4, None)
+        ]
     );
 }

--- a/scylla/src/frame/response/cql_to_rust.rs
+++ b/scylla/src/frame/response/cql_to_rust.rs
@@ -185,7 +185,7 @@ macro_rules! impl_tuple_from_cql {
     ( $($Ti:tt),+ ) => {
         impl<$($Ti),+> FromCqlVal<CqlValue> for ($($Ti,)+)
         where
-            $($Ti: FromCqlVal<CqlValue>),+
+            $($Ti: FromCqlVal<Option<CqlValue>>),+
         {
             fn from_cql(cql_val: CqlValue) -> Result<Self, FromCqlValError> {
                 let tuple_fields = match cql_val {


### PR DESCRIPTION
Tuples are now represented as `Vec<Option<CqlValue>>`.
Added test, that checks receiving tuples with null element.